### PR TITLE
Overhaul of options, working with node.js 4.x and later

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,9 @@ var fs = require('fs');
 var path = require('path');
 
 var tsc = path.join(path.dirname(require.resolve("typescript")),"tsc.js");
-var tscScript = vm.createScript(fs.readFileSync(tsc, "utf8"), tsc);
-var libPath = path.join(path.dirname(require.resolve("typescript")), "lib.d.ts")
+var tscScript = new vm.Script(fs.readFileSync(tsc, "utf8"), {
+  filename: tsc
+});
 
 var options = {
   nodeLib: false,
@@ -78,10 +79,14 @@ function compileTS (module) {
     require: require,
     module: module,
     Buffer: Buffer,
-    setTimeout: setTimeout
+    setTimeout: setTimeout,
+    __filename: tsc,
+    __dirname: path.dirname(tsc)
   };
 
-  tscScript.runInNewContext(sandbox);
+  tscScript.runInNewContext(sandbox, {
+    filename: tsc
+  });
   if (exitCode != 0) {
     throw new Error('Unable to compile TypeScript file.');
   }

--- a/index.js
+++ b/index.js
@@ -59,7 +59,9 @@ function compileTS (module) {
     "node",
     "tsc.js",
     "--outDir",
-    path.join(tmpDir, relativeFolder)
+    tmpDir,
+    "--rootDir",
+    process.cwd()
   ];
   Object.keys(options.tscOptions).forEach(function(k) {
     if (options.tscOptions[k] === false || disallowedOptions.indexOf(k) > -1) {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
       "email": "me@saulovallory.com"
     }
   ],
-  "version": "0.2.9-1",
+  "version": "1.0.0",
   "main": "./index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hi,

This is a pretty major set of changes, which allows a few things:

1) Arbitrary and unlimited options passed to tsc
    * this adds a tscOptions option which is an object containing all the parameters you want to use with tsc
    * this means that this module won't have to constantly change when people want more functionality

2) Use a tsconfig.json project instead of tsc options
    * If you specify a projectDir in the options it will ignore other options and pass -p <path> to the tsc command; it will also only run it once.  If you do this you should specify an outDir in your tsconfig.json file which is equivalent to the tmpDir passed into the typescript-require options.  This is far more efficient for large projects and also without this sometimes needed files don't get processed by typescript and things suddenly don't work.  Additionally, with a project you don't have to reference all your .d.ts files all the time.

I also fixed several bugs which I ran into and updated it to work with typescript 1.8.9 and node.js 4.x and later (some things were deprecated.

This could still use some cleanup, but I thought I'd submit this and ask: this is a pretty major change from your old way of doing things; do you want me to clean this up and you can accept the PR or should I just fork it and publish my own?  I couldn't have done it without your work, but these changes are absolutely necessary for my projects which are using them.