### PR TITLE
Pass `clearTimeout` and `__filename` in the sandbox to run `tsc`

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,9 @@ function compileTS (module) {
     require: require,
     module: module,
     Buffer: Buffer,
-    setTimeout: setTimeout
+    setTimeout: setTimeout,
+    clearTimeout: clearTimeout,
+    __filename: tsc
   };
 
   tscScript.runInNewContext(sandbox);


### PR DESCRIPTION
I've been working on a small unit test of the complex javascript codebase. I run into the issue to run `mocha` with `typescript-require` using the command below:

    ./node_modules/.bin/mocha --compilers js:babel-core/register,ts:typescript-require --require typescript-require --globals navigator ./test/**/*-spec.js

I found out that the package doesn't pass `clearTimeout()` and `__filename` in the sandbox that is used to define the `tsc` environment.

Having applied this fix, this could resolve similar issues like #48.