### PR TITLE
Add general extensibility to tsc call

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ It is possible to configure the require extension upon initialization:
         targetES5: true,
         exitOnError: true,
         emitOnError: true
+        cliOptions: ['--skipLibCheck']
     });
 
 ### nodeLib [boolean] default: false
@@ -78,6 +79,10 @@ The directory underneath which output files should be placed
 ### emitOnError [boolean] default: false
 
 Tells the TypeScript compiler whether or not to emit JS files if an error occurs.
+
+### emitOnError [string[]] default: []
+
+Will be appended to the tsc command line options.
 
 # Module Dependencies in TS files
 

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ var options = {
   exitOnError: true,
   tmpDir: path.join(process.cwd(), "tmp"),
   lib: ["DOM", "ScriptHost", "ES5", "ES6", "ES7", "esnext"],
+  cliOptions: [],
 };
 
 module.exports = function (opts) {
@@ -79,6 +80,7 @@ function compileTS(module) {
     "--lib",
     Array.isArray(options.lib) ? options.lib.join(",") : options.lib,
     module.filename,
+    ...options.cliOptions,
   ];
 
   var proc = merge(merge({}, process), {


### PR DESCRIPTION
The lack of the --skipLibCheck flag was causing problems for me. I added this in order to use that, but made it general enough that I imagine it might be useful without having to add custom config options for every use case.

Thanks! Appreciate this little lib!